### PR TITLE
Add Jojo Transcribe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@
 ## Apps
 
 - [Aiko](https://sindresorhus.com/aiko) - Audio transcription iOS and macOS app.
+- [Jojo Transcribe](https://apps.apple.com/app/apple-store/id1659864300) - Audio transcription macOS app.
 - [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) - Audio transcription macOS app. (Freemium)
 - [Whisper Memos](https://apps.apple.com/app/id6443658039) - Audio transcription iOS app. (Freemium)
 - [FourYou](https://apps.apple.com/app/id1671616134) - Audio journal iOS app.

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@
 - [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) - Audio transcription macOS app. (Freemium)
 - [Whisper Memos](https://apps.apple.com/app/id6443658039) - Audio transcription iOS app. (Freemium)
 - [FourYou](https://apps.apple.com/app/id1671616134) - Audio journal iOS app.
-- [Jojo Transcribe](https://apps.apple.com/app/apple-store/id1659864300) - Audio transcription macOS app.
+- [Jojo Transcribe](https://apps.apple.com/app/id1659864300) - Audio transcription macOS app.
 
 ## Web apps
 

--- a/readme.md
+++ b/readme.md
@@ -56,10 +56,10 @@
 ## Apps
 
 - [Aiko](https://sindresorhus.com/aiko) - Audio transcription iOS and macOS app.
-- [Jojo Transcribe](https://apps.apple.com/app/apple-store/id1659864300) - Audio transcription macOS app.
 - [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) - Audio transcription macOS app. (Freemium)
 - [Whisper Memos](https://apps.apple.com/app/id6443658039) - Audio transcription iOS app. (Freemium)
 - [FourYou](https://apps.apple.com/app/id1671616134) - Audio journal iOS app.
+- [Jojo Transcribe](https://apps.apple.com/app/apple-store/id1659864300) - Audio transcription macOS app.
 
 ## Web apps
 


### PR DESCRIPTION
Jojo Transcribe is powered by Whisper model and Whisper.cpp. Jojo Transcribe was developed by the Norwegian newspaper VG to enable journalists to transcribe interviews and still protect the identity of critical sources by not having to upload media to the internet.