### PR TITLE
Add Off Grid (on-device AI app with whisper.cpp transcription)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@
 - [EasyWhisper](https://easywhisper.io) - Windows and macOS app for audio transcription and speaker diarization. (Freemium)
 - [Audio Note](https://audionote.app) - Real-time audio transcription on macOS and Windows. (Freemium · Electron)
 - [Whisper](https://github.com/woheller69/whisperIME) - Android app for transcription and translation. (FOSS)
+- [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) - On-device AI assistant for iOS, Android, and Mac with voice transcription via whisper.cpp, plus chat, vision, and image generation. (FOSS)
 - [VoiceInk](https://github.com/Beingpax/VoiceInk) - Dictation and transcription macOS app. (FOSS)
 - [Ito AI](https://github.com/heyito/ito) - AI voice dictation for Mac. (FOSS)
 - [OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper) - Dictation app for macOS. (FOSS)


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile-ai) to the **Apps** section.

Off Grid ships whisper.cpp on iOS and Android in production for ~10K Android users — voice transcription is one of its core features. Mobile + desktop coverage complements the desktop-heavy entries in this section.

- Open-source iOS / Android / Apple Silicon Mac, MIT-licensed
- Voice transcription via whisper.cpp (no audio leaves the device)
- Plus on-device chat, vision, image generation, tool calling

Inserted after `Whisper (woheller69)` to keep the FOSS Android entries together.